### PR TITLE
feat(cli): add defaults for some args

### DIFF
--- a/doc/examples/docker-compose.yml
+++ b/doc/examples/docker-compose.yml
@@ -24,9 +24,3 @@ services:
       - your-email-address@example.com
       - -password
       - your-password
-      - -api-key
-      - p7ndMoj61npRZP5CVz9v4Uj0bG769xy6758QRBPb
-      - -client-id
-      - "IYXzWN908psOm7sNpe4G.ios.whisker.robots"
-      - -client-secret
-      - "C63CLXOmwNaqLTB2xXo6QIWGwwBamcPuaul"

--- a/main.go
+++ b/main.go
@@ -2,23 +2,31 @@ package main
 
 import (
 	"flag"
+	"net/http"
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
-	"net/http"
-	"time"
 )
 
 var (
-	apiKey       = flag.String("api-key", "", "litter robot api key")
+	apiKey       = flag.String("api-key", defaultApiKey, "litter robot api key")
 	email        = flag.String("email", "", "litter robot account email address")
 	password     = flag.String("password", "", "litter robot account password")
-	clientId     = flag.String("client-id", "", "litter robot client id")
-	clientSecret = flag.String("client-secret", "", "litter robot client secret")
+	clientId     = flag.String("client-id", defaultClientId, "litter robot client id")
+	clientSecret = flag.String("client-secret", defaultClientSecret, "litter robot client secret")
 	endpoint     = flag.String("api-url", "", "litter robot API URL")
 	authEndpoint = flag.String("auth-url", "", "litter robot auth URL")
 	address      = flag.String("address", "0.0.0.0:9080", "the server address")
 	logLevel     = flag.String("log-level", "info", "the log level")
+)
+
+// These values have been reverse-engineered from the mobile apps
+const (
+	defaultApiKey       = "p7ndMoj61npRZP5CVz9v4Uj0bG769xy6758QRBPb"
+	defaultClientId     = "IYXzWN908psOm7sNpe4G.ios.whisker.robots"
+	defaultClientSecret = "C63CLXOmwNaqLTB2xXo6QIWGwwBamcPuaul"
 )
 
 func init() {


### PR DESCRIPTION
Adds defaults for client ID, API key and client secret, which are set to
values that have been reverse engineered from the mobile app.

See #17